### PR TITLE
Release 1.2.2

### DIFF
--- a/com.github.ryonakano.pinit.yml
+++ b/com.github.ryonakano.pinit.yml
@@ -25,7 +25,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/ryonakano/pinit.git
-        tag: '1.2.1'
-        commit: aa09befa856f92640649bfa069694d3ce7232581
+        tag: '1.2.2'
+        commit: 5ca2a102bc4657021d0086b6f22ece011de8d147
       - type: patch
         path: appdata-screenshots.patch

--- a/com.github.ryonakano.pinit.yml
+++ b/com.github.ryonakano.pinit.yml
@@ -16,9 +16,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/elementary/granite.git
-        tag: '6.1.1'
-        commit: b2cf3b4c8a2fdd59daeefb396e9a846088f02b92
-
+        tag: '6.2.0'
+        commit: 4ab145c28bb3db6372fe519e8bd79c645edfcda3
   - name: pinit
     buildsystem: meson
     config-opts:


### PR DESCRIPTION
Also bump granite to 6.2.0. Blocking until we release 1.2.2 in the upstream repo
